### PR TITLE
Disable other envs than development

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
     env:
       REDMINE: ${{ matrix.redmine }}
       RAILS_ENV: test
+      ENABLE_REDMINE_LOGIN_BYPASS: 1
 
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This is a Redmine plugin allowing developers to login without passwords.
 $ git clone https://github.com/vzvu3k6k/redmine_login_bypass.git redmine/plugins
 ```
 
+This plugin is disabled on non-`development` environment. Set `ENABLE_REDMINE_LOGIN_BYPASS=1` to enable.
+
 ## Supported Redmine versions
 
 - Redmine 4.x

--- a/init.rb
+++ b/init.rb
@@ -1,20 +1,24 @@
-Redmine::Plugin.register :redmine_login_bypass do
-  name 'Redmine Login Bypass'
-  description 'Login without passwords'
-  version '1.0.0'
-  url 'https://github.com/vzvu3k6k/redmine_login_bypass'
-end
-
-require 'redmine_login_bypass/hook'
-
-# ActionDispatch::Reloader is deprecated in Rails 5 (Redmine 4).
-reloader =
-  if defined? ActiveSupport::Reloader
-    ActiveSupport::Reloader
-  else
-    ActionDispatch::Reloader
+# Disable on non-development environments by default
+# so that it won't affect other plugin's tests or open a backdoor in production
+if Rails.env.development? || ENV['ENABLE_REDMINE_LOGIN_BYPASS'] == '1'
+  Redmine::Plugin.register :redmine_login_bypass do
+    name 'Redmine Login Bypass'
+    description 'Login without passwords'
+    version '1.0.0'
+    url 'https://github.com/vzvu3k6k/redmine_login_bypass'
   end
 
-reloader.to_prepare do
-  User.prepend RedmineLoginBypass::UserPatch
+  require 'redmine_login_bypass/hook'
+
+  # ActionDispatch::Reloader is deprecated in Rails 5 (Redmine 4).
+  reloader =
+    if defined? ActiveSupport::Reloader
+      ActiveSupport::Reloader
+    else
+      ActionDispatch::Reloader
+    end
+
+  reloader.to_prepare do
+    User.prepend RedmineLoginBypass::UserPatch
+  end
 end


### PR DESCRIPTION
Note: Redmine 3.x and 4.x supports > Ruby 2.4, which doesn't support top-level return.